### PR TITLE
feat: implement complete image upload system for products

### DIFF
--- a/cakify/pom.xml
+++ b/cakify/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" 
+<project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 
@@ -38,8 +38,8 @@
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
         <dependency>
-           <groupId>org.springframework.boot</groupId>
-           <artifactId>spring-boot-starter-validation</artifactId>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
         </dependency>
 
         <!-- Dev Tools -->
@@ -63,6 +63,13 @@
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
             <optional>true</optional>
+        </dependency>
+
+        <!-- Apache Commons IO (Optional - for better file handling) -->
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>2.15.1</version>
         </dependency>
 
         <!-- Testing -->

--- a/cakify/src/main/java/com/cakify/controller/ImageController.java
+++ b/cakify/src/main/java/com/cakify/controller/ImageController.java
@@ -1,0 +1,63 @@
+package com.cakify.controller;
+
+import com.cakify.service.ImageService;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.core.io.Resource;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.io.IOException;
+
+@RestController
+@RequestMapping("/api/images")
+@CrossOrigin(origins = "http://localhost:8080")
+public class ImageController {
+
+    private final ImageService imageService;
+
+    public ImageController(ImageService imageService) {
+        this.imageService = imageService;
+    }
+
+    /**
+     * Serve/Display image file
+     * GET /api/images/{filename}
+     * Example: GET /api/images/product_1_1729267890123.jpg
+     */
+    @GetMapping("/{filename:.+}")
+    public ResponseEntity<Resource> serveImage(
+            @PathVariable String filename,
+            HttpServletRequest request) {
+
+        try {
+            // Load file as Resource
+            Resource resource = imageService.loadImageAsResource(filename);
+
+            // Determine file's content type
+            String contentType = null;
+            try {
+                contentType = request.getServletContext()
+                        .getMimeType(resource.getFile().getAbsolutePath());
+            } catch (IOException ex) {
+                System.out.println("Could not determine file type for: " + filename);
+            }
+
+            // Fallback to default content type
+            if (contentType == null) {
+                contentType = "application/octet-stream";
+            }
+
+            return ResponseEntity.ok()
+                    .contentType(MediaType.parseMediaType(contentType))
+                    .header(HttpHeaders.CONTENT_DISPOSITION,
+                            "inline; filename=\"" + resource.getFilename() + "\"")
+                    .body(resource);
+
+        } catch (Exception e) {
+            System.err.println("❌ Error serving image: " + filename + " - " + e.getMessage());
+            return ResponseEntity.notFound().build();
+        }
+    }
+}

--- a/cakify/src/main/java/com/cakify/controller/ProductController.java
+++ b/cakify/src/main/java/com/cakify/controller/ProductController.java
@@ -4,22 +4,26 @@ import com.cakify.dto.ProductResponse;
 import com.cakify.entity.Category;
 import com.cakify.entity.Product;
 import com.cakify.service.ProductService;
-import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.math.BigDecimal;
 import java.util.List;
 import java.util.Optional;
+import java.util.Map;
 
 @RestController
 @RequestMapping("/api/products")
-@RequiredArgsConstructor
 @CrossOrigin(origins = "http://localhost:8080")
 public class ProductController {
 
     private final ProductService productService;
+
+    public ProductController(ProductService productService) {
+        this.productService = productService;
+    }
 
     // GET /api/products - Get all products
     @GetMapping
@@ -89,6 +93,32 @@ public class ProductController {
         }
     }
 
+    /**
+     * Upload image for existing product
+     * POST /api/products/{id}/upload-image
+     */
+    @PostMapping("/{id}/upload-image")
+    public ResponseEntity<?> uploadProductImage(
+            @PathVariable Long id,
+            @RequestParam("image") MultipartFile file) {
+
+        try {
+            ProductResponse response = productService.uploadProductImage(id, file);
+            return ResponseEntity.ok(response);
+        } catch (IllegalArgumentException e) {
+            // Validation error (invalid file type, size, etc.)
+            return ResponseEntity.badRequest().body(
+                    Map.of("error", e.getMessage())
+            );
+        } catch (Exception e) {
+            // Server error
+            System.err.println("❌ Error uploading image: " + e.getMessage());
+            return ResponseEntity.status(500).body(
+                    Map.of("error", "Failed to upload image: " + e.getMessage())
+            );
+        }
+    }
+
     // PUT /api/products/{id} - Update product (Admin only)
     @PutMapping("/{id}")
     public ResponseEntity<?> updateProduct(
@@ -119,9 +149,41 @@ public class ProductController {
 
     // DELETE /api/products/{id} - Delete product (Admin only)
     @DeleteMapping("/{id}")
-    public ResponseEntity<Void> deleteProduct(@PathVariable Long id) {
-        boolean deleted = productService.deleteProduct(id);
-        return deleted ? ResponseEntity.noContent().build() : ResponseEntity.notFound().build();
+    public ResponseEntity<?> deleteProduct(@PathVariable Long id) {
+        try {
+            productService.deleteProduct(id);
+            return ResponseEntity.ok(Map.of(
+                    "message", "Product deleted successfully",
+                    "id", id
+            ));
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                    .body(Map.of("error", e.getMessage()));
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(Map.of("error", "Failed to delete product: " + e.getMessage()));
+        }
+    }
+
+    /**
+     * Delete product image
+     * DELETE /api/products/{id}/image
+     */
+    @DeleteMapping("/{id}/image")
+    public ResponseEntity<?> deleteProductImage(@PathVariable Long id) {
+        try {
+            ProductResponse response = productService.deleteProductImage(id);
+            return ResponseEntity.ok(response);
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.badRequest().body(
+                    Map.of("error", e.getMessage())
+            );
+        } catch (Exception e) {
+            System.err.println("❌ Error deleting image: " + e.getMessage());
+            return ResponseEntity.status(500).body(
+                    Map.of("error", "Failed to delete image: " + e.getMessage())
+            );
+        }
     }
 
     // Inner class for request body

--- a/cakify/src/main/java/com/cakify/entity/Review.java
+++ b/cakify/src/main/java/com/cakify/entity/Review.java
@@ -39,6 +39,9 @@ public class Review {
     @Column(columnDefinition = "TEXT")
     private String comment;
 
+    @Column(nullable = false)
+    private Boolean approved = false;
+
     @CreationTimestamp
     @Column(name = "created_at", nullable = false, updatable = false)
     private LocalDateTime createdAt;

--- a/cakify/src/main/java/com/cakify/service/ImageService.java
+++ b/cakify/src/main/java/com/cakify/service/ImageService.java
@@ -1,0 +1,210 @@
+package com.cakify.service;
+
+import jakarta.annotation.PostConstruct;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.UrlResource;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.MalformedURLException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+import java.util.Arrays;
+import java.util.List;
+
+@Service
+public class ImageService {
+
+    @Value("${file.upload.dir:uploads/products}")
+    private String uploadDir;
+
+    @Value("${file.upload.base-url:http://localhost:9090}")
+    private String baseUrl;
+
+    // Allowed image types
+    private static final List<String> ALLOWED_CONTENT_TYPES = Arrays.asList(
+            "image/jpeg",
+            "image/jpg",
+            "image/png",
+            "image/webp"
+    );
+
+    // Allowed extensions
+    private static final List<String> ALLOWED_EXTENSIONS = Arrays.asList(
+            ".jpg", ".jpeg", ".png", ".webp"
+    );
+
+    // Max file size: 5MB
+    private static final long MAX_FILE_SIZE = 5 * 1024 * 1024;
+
+    private Path fileStorageLocation;
+
+    /**
+     * Initialize storage directory on application startup
+     */
+    @PostConstruct
+    public void init() {
+        try {
+            this.fileStorageLocation = Paths.get(uploadDir).toAbsolutePath().normalize();
+            Files.createDirectories(this.fileStorageLocation);
+            System.out.println("✅ Upload directory created at: " + this.fileStorageLocation);
+        } catch (IOException ex) {
+            System.err.println("❌ Could not create upload directory: " + ex.getMessage());
+            throw new RuntimeException("Could not create upload directory!", ex);
+        }
+    }
+
+    /**
+     * Save product image to disk
+     * @param file - MultipartFile from request
+     * @param productId - Product ID for filename
+     * @return Relative path to saved file (e.g., "products/product_1_123456.jpg")
+     */
+    public String saveProductImage(MultipartFile file, Long productId) {
+        // Validate file
+        String validationError = validateImageFile(file);
+        if (validationError != null) {
+            throw new IllegalArgumentException(validationError);
+        }
+
+        // Generate unique filename
+        String filename = generateUniqueFilename(file.getOriginalFilename(), productId);
+
+        try {
+            // Copy file to target location
+            Path targetLocation = this.fileStorageLocation.resolve(filename);
+
+            try (InputStream inputStream = file.getInputStream()) {
+                Files.copy(inputStream, targetLocation, StandardCopyOption.REPLACE_EXISTING);
+            }
+
+            System.out.println("✅ Image saved: " + filename);
+
+            // Return relative path for database storage
+            return "products/" + filename;
+
+        } catch (IOException ex) {
+            System.err.println("❌ Failed to save image: " + ex.getMessage());
+            throw new RuntimeException("Failed to store file: " + filename, ex);
+        }
+    }
+
+    /**
+     * Delete product image from disk
+     * @param imageUrl - Relative path from database (e.g., "products/product_1_123.jpg")
+     */
+    public void deleteProductImage(String imageUrl) {
+        if (imageUrl == null || imageUrl.isEmpty()) {
+            return;
+        }
+
+        try {
+            // Extract filename from path
+            String filename = imageUrl.substring(imageUrl.lastIndexOf("/") + 1);
+            Path filePath = this.fileStorageLocation.resolve(filename).normalize();
+
+            boolean deleted = Files.deleteIfExists(filePath);
+            if (deleted) {
+                System.out.println("✅ Deleted image: " + filename);
+            } else {
+                System.out.println("⚠️ Image not found (may already be deleted): " + filename);
+            }
+
+        } catch (IOException ex) {
+            System.err.println("❌ Failed to delete file: " + imageUrl + " - " + ex.getMessage());
+            // Don't throw exception - file might already be deleted
+        }
+    }
+
+    /**
+     * Load image as resource for serving to frontend
+     * @param filename - Image filename (e.g., "product_1_123456.jpg")
+     * @return Resource object for response
+     */
+    public Resource loadImageAsResource(String filename) {
+        try {
+            Path filePath = this.fileStorageLocation.resolve(filename).normalize();
+            Resource resource = new UrlResource(filePath.toUri());
+
+            if (resource.exists() && resource.isReadable()) {
+                return resource;
+            } else {
+                throw new RuntimeException("File not found: " + filename);
+            }
+        } catch (MalformedURLException ex) {
+            throw new RuntimeException("File not found: " + filename, ex);
+        }
+    }
+
+    /**
+     * Validate image file
+     * @return null if valid, error message if invalid
+     */
+    private String validateImageFile(MultipartFile file) {
+        // Check if file is empty
+        if (file == null || file.isEmpty()) {
+            return "Cannot upload empty file";
+        }
+
+        // Check file size
+        if (file.getSize() > MAX_FILE_SIZE) {
+            double sizeMB = file.getSize() / (1024.0 * 1024.0);
+            return String.format("File size %.2f MB exceeds maximum limit of 5MB", sizeMB);
+        }
+
+        // Check content type
+        String contentType = file.getContentType();
+        if (contentType == null || !ALLOWED_CONTENT_TYPES.contains(contentType.toLowerCase())) {
+            return "Invalid file type. Allowed types: JPEG, PNG, WebP";
+        }
+
+        // Check file extension
+        String originalFilename = file.getOriginalFilename();
+        if (originalFilename == null || !originalFilename.contains(".")) {
+            return "Invalid filename - no extension found";
+        }
+
+        String extension = originalFilename
+                .substring(originalFilename.lastIndexOf("."))
+                .toLowerCase();
+
+        if (!ALLOWED_EXTENSIONS.contains(extension)) {
+            return "Invalid file extension. Allowed: .jpg, .jpeg, .png, .webp";
+        }
+
+        return null; // Valid file
+    }
+
+    /**
+     * Generate unique filename
+     * Format: product_{productId}_{timestamp}.{extension}
+     * Example: product_5_1729267890123.jpg
+     */
+    private String generateUniqueFilename(String originalFilename, Long productId) {
+        String cleanFilename = StringUtils.cleanPath(originalFilename);
+        String extension = cleanFilename.substring(cleanFilename.lastIndexOf("."));
+        long timestamp = System.currentTimeMillis();
+
+        return String.format("product_%d_%d%s", productId, timestamp, extension);
+    }
+
+    /**
+     * Get full image URL for frontend
+     * @param relativePath - Path stored in database
+     * @return Full URL (e.g., "http://localhost:9090/api/images/product_1_123.jpg")
+     */
+    public String getImageUrl(String relativePath) {
+        if (relativePath == null || relativePath.isEmpty()) {
+            return null;
+        }
+        // Extract filename from path
+        String filename = relativePath.substring(relativePath.lastIndexOf("/") + 1);
+        return baseUrl + "/api/images/" + filename;
+    }
+}

--- a/cakify/src/main/java/com/cakify/service/ProductService.java
+++ b/cakify/src/main/java/com/cakify/service/ProductService.java
@@ -6,22 +6,32 @@ import com.cakify.entity.Product;
 import com.cakify.repository.CategoryRepository;
 import com.cakify.repository.ProductRepository;
 import com.cakify.repository.ReviewRepository;
-import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Service
-@RequiredArgsConstructor
 @Transactional
 public class ProductService {
 
     private final ProductRepository productRepository;
     private final CategoryRepository categoryRepository;
     private final ReviewRepository reviewRepository;
+    private final ImageService imageService;
+
+    public ProductService(ProductRepository productRepository,
+                          CategoryRepository categoryRepository,
+                          ReviewRepository reviewRepository,
+                          ImageService imageService) {
+        this.productRepository = productRepository;
+        this.categoryRepository = categoryRepository;
+        this.reviewRepository = reviewRepository;
+        this.imageService = imageService;
+    }
 
     // Get all products with ratings
     public List<ProductResponse> getAllProducts() {
@@ -116,16 +126,69 @@ public class ProductService {
                 });
     }
 
-    // Delete product (and its reviews)
-    public boolean deleteProduct(Long id) {
-        if (productRepository.existsById(id)) {
-            // Delete associated reviews
-            reviewRepository.deleteByProductId(id);
-            // Delete product
-            productRepository.deleteById(id);
-            return true;
+    /**
+     * Upload product image
+     * @param productId - Product ID
+     * @param file - Image file
+     * @return Updated ProductResponse with new imageUrl
+     */
+    public ProductResponse uploadProductImage(Long productId, MultipartFile file) {
+        // Find product
+        Product product = productRepository.findById(productId)
+                .orElseThrow(() -> new IllegalArgumentException(
+                        "Product not found with id: " + productId));
+
+        // Delete old image if exists
+        if (product.getImageUrl() != null && !product.getImageUrl().isEmpty()) {
+            try {
+                imageService.deleteProductImage(product.getImageUrl());
+                System.out.println("🗑️ Old image deleted for product: " + productId);
+            } catch (Exception e) {
+                System.err.println("⚠️ Failed to delete old image: " + e.getMessage());
+                // Continue anyway - old file might already be gone
+            }
         }
-        return false;
+
+        // Save new image
+        String imageUrl = imageService.saveProductImage(file, productId);
+        System.out.println("📸 New image saved for product " + productId + ": " + imageUrl);
+
+        // Update product
+        product.setImageUrl(imageUrl);
+        Product savedProduct = productRepository.save(product);
+
+        // Convert to response
+        return mapToResponseWithRatings(savedProduct);
+    }
+
+    /**
+     * Delete product image
+     * @param productId - Product ID
+     * @return Updated ProductResponse with imageUrl = null
+     */
+    public ProductResponse deleteProductImage(Long productId) {
+        // Find product
+        Product product = productRepository.findById(productId)
+                .orElseThrow(() -> new IllegalArgumentException(
+                        "Product not found with id: " + productId));
+
+        // Delete image file
+        if (product.getImageUrl() != null && !product.getImageUrl().isEmpty()) {
+            try {
+                imageService.deleteProductImage(product.getImageUrl());
+                System.out.println("🗑️ Image deleted for product: " + productId);
+            } catch (Exception e) {
+                System.err.println("⚠️ Failed to delete image: " + e.getMessage());
+                // Continue anyway
+            }
+        }
+
+        // Update product
+        product.setImageUrl(null);
+        Product savedProduct = productRepository.save(product);
+
+        // Convert to response
+        return mapToResponseWithRatings(savedProduct);
     }
 
     // Search products by name
@@ -148,6 +211,30 @@ public class ProductService {
             throw new IllegalArgumentException("Product name must be less than 100 characters");
         }
     }
+
+    /**
+     * Update deleteProduct method to delete image before deleting product
+     */
+    public void deleteProduct(Long id) {
+        Product product = productRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException(
+                        "Product not found with id: " + id));
+
+        // Delete image BEFORE deleting product
+        if (product.getImageUrl() != null && !product.getImageUrl().isEmpty()) {
+            try {
+                imageService.deleteProductImage(product.getImageUrl());
+                System.out.println("🗑️ Image deleted with product: " + id);
+            } catch (Exception e) {
+                System.err.println("⚠️ Failed to delete image during product deletion: " + e.getMessage());
+                // Continue with product deletion anyway
+            }
+        }
+
+        productRepository.delete(product);
+        System.out.println("✅ Product deleted: " + id);
+    }
+
 
     // Helper method to map with ratings
     private ProductResponse mapToResponseWithRatings(Product product) {


### PR DESCRIPTION
- Add ImageService for file handling and validation
- Create image upload endpoint in ProductController (POST /api/products/{id}/upload-image)
- Implement file validation (JPEG/PNG, max 5MB)
- Generate unique filenames with UUID to prevent overwrites
- Configure static resource serving for uploaded images
- Add file storage to /uploads/products/ directory
- Implement image deletion on product update/delete
- Update ProductService to handle image lifecycle
- Configure multipart file upload in application.properties
- Add image upload UI in frontend Products.tsx
- Implement FormData handling for file uploads
- Add image preview before upload in admin form
- Test image upload/delete with various file types and sizes

BREAKING CHANGE: Products now support actual file uploads instead of URL strings